### PR TITLE
Tune passed pawn scores

### DIFF
--- a/Bit-Genie/src/eval.cpp
+++ b/Bit-Genie/src/eval.cpp
@@ -115,8 +115,14 @@ static constexpr int mobility_score(Callable F, Args... args)
 }
 
 static constexpr int passed_pawn_scores[total_ranks] = {
-	S(0,  0) , S(-16, 22), S(-16, 25), S(-7, 56),
-	S(26, 80), S(60,139) , S(136,196), S(0,  0),
+	S( 0, 0 ),
+    S( -16, -16 ),
+    S( -24, -24 ),
+    S( 2, 2 ),
+    S( 55, 54 ),
+    S( 162, 162 ),
+    S( 228, 228 ),
+    S( 0, 0),
 };
 
 static bool material_draw(Position const& position)


### PR DESCRIPTION
 tc: 4 + 0.2s
```
Score of Dev vs Master: 257 - 181 - 162  [0.563] 600
...      Dev playing White: 140 - 79 - 81  [0.602] 300
...      Dev playing Black: 117 - 102 - 81  [0.525] 300
...      White vs Black: 242 - 196 - 162  [0.538] 600
Elo difference: 44.2 +/- 23.9, LOS: 100.0 %, DrawRatio: 27.0 %
```