### PR TITLE
Exclude squares attacked by enemy pawns for knight mobility.

### DIFF
--- a/Bit-Genie/src/uci.cpp
+++ b/Bit-Genie/src/uci.cpp
@@ -25,7 +25,7 @@
 #include "benchmark.h"
 #include "searchinit.h"
 
-const char *version = "3.4.5";
+const char *version = "3.5";
 
 namespace
 {


### PR DESCRIPTION
Bench: 40224792

Previously considered all squares that a knight can reach from a square as its 'mobility' squares. Now remove the squares that are attacked by enemy pawns

```
ELO   | 11.87 +- 7.60 (95%)
SPRT  | 4+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5972 W: 2325 L: 2121 D: 1526
```