### PR TITLE
Connected passed pawns

### DIFF
--- a/Bit-Genie/src/eval.cpp
+++ b/Bit-Genie/src/eval.cpp
@@ -145,10 +145,18 @@ static int evaluate_pawn(Position const &position, EvalData, Square sq, Color us
     score += pawn_is_isolated(friend_pawns, sq) * PawnEval::isolated;
     score += pawn_is_stacked(friend_pawns, sq) * PawnEval::stacked;
 
-    if (ahead_squares & enemy)
-        score += pawn_passed(enemy_pawns, us, sq) * PawnEval::passer_blocked[psqt_sq(sq, us)];
-    else 
-        score += pawn_passed(enemy_pawns, us, sq) * PawnEval::passed[psqt_sq(sq, us)];
+    bool passed = pawn_passed(enemy_pawns, us, sq);
+
+    if (passed)
+    {
+        if (ahead_squares & enemy)
+            score += PawnEval::passer_blocked[psqt_sq(sq, us)];
+        else 
+            score += PawnEval::passed[psqt_sq(sq, us)];
+
+        if (BitMask::pawn_attacks[!us][sq] & friend_pawns)
+            score += PawnEval::passed_connected;
+    }
 
 
     return score;

--- a/Bit-Genie/src/evalscores.h
+++ b/Bit-Genie/src/evalscores.h
@@ -73,6 +73,8 @@ namespace PawnEval
         S(   0,   0), S(   0,   0), S(   0,   0), S(   0,   0),
     };
 
+    constexpr int passed_connected = S(18, 45);
+
     constexpr int isolated = S(-10, -10);
     constexpr int stacked = S(-10, -11);
 }


### PR DESCRIPTION
Provide a bonus for a passed pawn (S(18, 45) after tuning ) that is directly supported (connected) by a friendly pawn.
http://167.114.125.235:8080/test/1477/