### PR TITLE
NMP depth reduction according to depth 

### DIFF
--- a/Bit-Genie/src/eval.cpp
+++ b/Bit-Genie/src/eval.cpp
@@ -230,7 +230,7 @@ static int evaluate_bishop(Position const &position, EvalData &data, Square sq, 
 
     score += BishopEval::psqt[psqt_sq(sq, us)];
     score += calculate_moblity<Bishop>(position, data, sq, us, BishopEval::mobility);
-    score += BishopEval::value;
+    score += BishopEval::value; 
 
     return score;
 }

--- a/Bit-Genie/src/search.cpp
+++ b/Bit-Genie/src/search.cpp
@@ -150,8 +150,10 @@ namespace
 
         if (!pv_node && !in_check && depth > 4 && search.info.ply && do_null && position.should_do_null())
         {
+            int R = depth / 7 + 4;
+
             position.apply_null_move(search.info.ply);
-            int score = -pvs(position, search, tt, depth - 4, -beta, -beta + 1, false, false).score;
+            int score = -pvs(position, search, tt, depth - R, -beta, -beta + 1, false, false).score;
             position.revert_null_move(search.info.ply);
 
             if (search.limits.stopped)

--- a/Bit-Genie/src/search.cpp
+++ b/Bit-Genie/src/search.cpp
@@ -150,7 +150,7 @@ namespace
 
         if (!pv_node && !in_check && depth > 4 && search.info.ply && do_null && position.should_do_null())
         {
-            int R = depth / 7 + 4;
+            int R = depth / 4 + 4;
 
             position.apply_null_move(search.info.ply);
             int score = -pvs(position, search, tt, depth - R, -beta, -beta + 1, false, false).score;

--- a/Bit-Genie/src/uci.cpp
+++ b/Bit-Genie/src/uci.cpp
@@ -25,7 +25,7 @@
 #include "benchmark.h"
 #include "searchinit.h"
 
-const char *version = "5.4";
+const char *version = "5.45";
 
 namespace
 {


### PR DESCRIPTION
Use a new formula to calculate the reduction for null-move pruning instead of a constant 4
![desmos-graph](https://user-images.githubusercontent.com/68417405/121844878-453a2800-cd02-11eb-9e3d-2391efcadef7.png)

The black line shows the increase in reduction as the depth increases
