### PR TITLE
NMP eval condition

### DIFF
--- a/Bit-Genie/src/search.cpp
+++ b/Bit-Genie/src/search.cpp
@@ -161,7 +161,9 @@ namespace
                }
         }
 
-        if (!pv_node && !in_check && depth > 4 && !at_root && do_null && position.should_do_null())
+        int eval = eval_position(position);
+
+        if (!pv_node && !in_check && eval >= beta && depth > 4 && !at_root && do_null && position.should_do_null())
         {
             int R = std::max(4, 3 + depth / 5);
 

--- a/Bit-Genie/src/uci.cpp
+++ b/Bit-Genie/src/uci.cpp
@@ -26,7 +26,7 @@
 #include "searchinit.h"
 #include "polyglot.h"
 
-const char *version = "6.55";
+const char *version = "6.6";
 
 namespace
 {


### PR DESCRIPTION
Only try null move pruning when static eval is greater than beta