### PR TITLE
Improve TT replacement scheme

### DIFF
--- a/Bit-Genie/src/tt.cpp
+++ b/Bit-Genie/src/tt.cpp
@@ -38,7 +38,7 @@ void TTable::add(Position const &position, Move move, int16_t score, uint8_t dep
     uint64_t hash = position.key.data();
     uint64_t index = hash % entries.size(); 
 
-    if (hash == entries[index].hash && depth < entries[index].depth) return;
+    if (flag != TEFlag::exact && hash == entries[index].hash && depth < entries[index].depth) return;
 
     entries[index] = TEntry(hash, score, move, depth, flag, seval);
 }

--- a/Bit-Genie/src/tt.cpp
+++ b/Bit-Genie/src/tt.cpp
@@ -38,6 +38,8 @@ void TTable::add(Position const &position, Move move, int16_t score, uint8_t dep
     uint64_t hash = position.key.data();
     uint64_t index = hash % entries.size(); 
 
+    if (hash == entries[index].hash && depth < entries[index].depth) return;
+
     entries[index] = TEntry(hash, score, move, depth, flag, seval);
 }
 


### PR DESCRIPTION
Only replace entries of the same positions if depth isn't lower or exact score is stored 

```
ELO   | 6.49 +- 4.82 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=2MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 11888 W: 3666 L: 3444 D: 4778
```
https://ob.koibois.net/test/2335/