### PR TITLE
Capture history penalty 

### DIFF
--- a/Bit-Genie/src/search.cpp
+++ b/Bit-Genie/src/search.cpp
@@ -255,7 +255,7 @@ namespace
                     add_killer(search, move);
                 }
                 else 
-                    history_bonus(search.capture_history, position, move, depth);
+                    update_history(search.capture_history, position, move, picker.gen.movelist, depth);
 
                 break;
             }

--- a/Bit-Genie/src/uci.cpp
+++ b/Bit-Genie/src/uci.cpp
@@ -27,7 +27,7 @@
 #include "polyglot.h"
 #include <cstring>
 
-const char *version = "7.29";
+const char *version = "7.3";
 
 namespace
 {


### PR DESCRIPTION
Provide a penalty to all the moves that didn't cause a cutoff for capture history, just like the quiet history table 
https://ob.koibois.net/test/2380/