### PR TITLE
Capture history tweak 

### DIFF
--- a/Bit-Genie/src/moveorder.cpp
+++ b/Bit-Genie/src/moveorder.cpp
@@ -99,7 +99,7 @@ static void score_movelist(Movelist &movelist, Search::Info& search)
         {
             int score = see(position, move);
 
-            score += get_history(search.capture_history, position, move) / 128;
+            score += get_history(search.capture_history, position, move) / 64;
 
             set_move_score(move, score);
         }

--- a/Bit-Genie/src/uci.cpp
+++ b/Bit-Genie/src/uci.cpp
@@ -27,7 +27,7 @@
 #include "polyglot.h"
 #include <cstring>
 
-const char *version = "7.3";
+const char *version = "7.31";
 
 namespace
 {


### PR DESCRIPTION
Reduce capture history divisor making its impact more significant in move-ordering
https://ob.koibois.net/test/2382/