### PR TITLE
Sort equal captures over killers

### DIFF
--- a/Bit-Genie/src/moveorder.cpp
+++ b/Bit-Genie/src/moveorder.cpp
@@ -183,7 +183,7 @@ bool MovePicker::next(Move &move)
 
     if (stage == Stage::GiveGoodNoisy)
     {
-        if (current != gen.movelist.end() && move_score(*current) > 0)
+        if (current != gen.movelist.end() && move_score(*current) >= 0)
         {
             move = *current++;
             bubble_top_move(current, gen.movelist.end());

--- a/Bit-Genie/src/uci.cpp
+++ b/Bit-Genie/src/uci.cpp
@@ -27,7 +27,7 @@
 #include "polyglot.h"
 #include <cstring>
 
-const char *version = "7.3";
+const char *version = "7.31";
 
 namespace
 {


### PR DESCRIPTION
Consider equal captures in the `MovePicker::GoodNoisy` stage and sort them above killer moves
https://ob.koibois.net/test/2383/