### PR TITLE
Adjust mate score when using TT

### DIFF
--- a/src/tt.h
+++ b/src/tt.h
@@ -53,7 +53,9 @@ public:
     TTable(int mb) { resize(mb); }
 
     void resize(int);
+   
     void add(Position const &, Move, int16_t score, uint8_t depth, TEFlag, int16_t);
+   
     void reset()
     {
         std::fill(entries.begin(), entries.end(), TEntry());
@@ -63,6 +65,7 @@ public:
 
     std::vector<Move> extract_pv(Position&, int);
 
+    
 private:
     std::vector<TEntry> entries;
 };

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -27,7 +27,7 @@
 #include "polyglot.h"
 #include <cstring>
 
-const char *version = "8.02";
+const char *version = "8.03";
 
 namespace
 {


### PR DESCRIPTION
Adjust mate score when storing / retrieving from TT according to the current ply. Absence of this causes invalid mate distance reporting 

https://ob.koibois.net/test/2641/