### PR TITLE
Consider increment for time-management

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -94,6 +94,7 @@ namespace
         if (options.movetime == -1)
         {
             auto &t = position.side == White ? options.wtime : options.btime;
+            auto &inc = position.side == White ? options.winc  : options.binc;
 
             if (t == -1)
                 search.limits.movetime = std::numeric_limits<int64_t>::max();
@@ -101,7 +102,7 @@ namespace
             else
             {
                 search.limits.time_set = true;
-                search.limits.movetime = t / options.movestogo - 50;
+                search.limits.movetime = t / options.movestogo + inc - 50;
             }
         }
         else

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -27,7 +27,7 @@
 #include "polyglot.h"
 #include <cstring>
 
-const char *version = "8.16";
+const char *version = "8.17";
 
 namespace
 {

--- a/src/uciparse.h
+++ b/src/uciparse.h
@@ -40,7 +40,7 @@ enum class UciCommands
 struct UciGo
 {
     int depth = 64;
-    int movestogo = 30;
+    int movestogo = 20;
 
     int64_t btime = -1;
     int64_t wtime = -1;

--- a/src/uciparse.h
+++ b/src/uciparse.h
@@ -40,7 +40,7 @@ enum class UciCommands
 struct UciGo
 {
     int depth = 64;
-    int movestogo = 15;
+    int movestogo = 20;
 
     int64_t btime = -1;
     int64_t wtime = -1;

--- a/src/uciparse.h
+++ b/src/uciparse.h
@@ -40,7 +40,7 @@ enum class UciCommands
 struct UciGo
 {
     int depth = 64;
-    int movestogo = 20;
+    int movestogo = 30;
 
     int64_t btime = -1;
     int64_t wtime = -1;

--- a/src/uciparse.h
+++ b/src/uciparse.h
@@ -40,7 +40,7 @@ enum class UciCommands
 struct UciGo
 {
     int depth = 64;
-    int movestogo = 20;
+    int movestogo = 15;
 
     int64_t btime = -1;
     int64_t wtime = -1;


### PR DESCRIPTION
https://ob.koibois.net/test/2913/
https://ob.koibois.net/test/2912/

```
ELO   | 41.26 +- 14.03 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 1176 W: 361 L: 222 D: 593
```


```
ELO   | 59.69 +- 17.93 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 864 W: 326 L: 179 D: 359
```