### PR TITLE
Qsearch when eval is far below alpha 

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -246,7 +246,7 @@ namespace
         if (!at_root && !in_check && depth < 6 && (eval - rfp_margin[depth] / (improving + 1)) >= beta )
             return eval;
 
-        if (!at_root && !in_check && depth == 1 && eval + 350 <= alpha)
+        if (!pv_node && !in_check && depth == 1 && eval + 400 <= alpha)
             return qsearch(search, alpha, beta);
 
         if (!pv_node && !in_check && depth >= 4 && do_null && position.should_do_null() && eval + 300 >= beta)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -246,6 +246,9 @@ namespace
         if (!at_root && !in_check && depth < 6 && (eval - rfp_margin[depth] / (improving + 1)) >= beta )
             return eval;
 
+        if (!at_root && !in_check && depth == 1 && eval + 350 <= alpha)
+            return qsearch(search, alpha, beta);
+
         if (!pv_node && !in_check && depth >= 4 && do_null && position.should_do_null() && eval + 300 >= beta)
         {
             position.apply_null_move(search.stats.ply);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -27,7 +27,7 @@
 #include "polyglot.h"
 #include <cstring>
 
-const char *version = "8.21";
+const char *version = "8.22";
 
 namespace
 {


### PR DESCRIPTION
Don't search any moves if eval is far below alpha at depth 1
https://ob.koibois.net/test/3022/