### PR TITLE
Update all history tables on tt cutoffs

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -258,8 +258,8 @@ namespace
                (entry.flag == TEFlag::lower && score >= beta) || 
                (entry.flag == TEFlag::upper && score <= alpha))
                {
-                    if (!move_is_capture(position, move) && score >= beta)
-                        history_bonus(search.history, position, move, depth);
+                    if (score >= beta)
+                        update_history_tables_on_cutoff(search, picker.movelist, move, depth);
                         
                     return { score, move };
                }

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -27,7 +27,7 @@
 #include "polyglot.h"
 #include <cstring>
 
-const char *version = "8.32";
+const char *version = "8.33";
 
 namespace
 {


### PR DESCRIPTION
https://ob.koibois.net/test/3477/

```
ELO   | 6.82 +- 4.95 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 10032 W: 2766 L: 2569 D: 4697
```