### PR TITLE
Avoid repeating moves in search 

### DIFF
--- a/src/moveorder.h
+++ b/src/moveorder.h
@@ -42,6 +42,10 @@ public:
     Movelist movelist;
     Stage stage = Stage::HashMove;
     bool skip_quiets = false;
+    Move hash_move = NullMove;
+    Move killer1 = NullMove;
+    Move killer2 = NullMove;
+
 private:
     Search::Info *search;
     Movelist::iterator current;

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -27,7 +27,7 @@
 #include "polyglot.h"
 #include <cstring>
 
-const char *version = "8.34";
+const char *version = "8.35";
 
 namespace
 {


### PR DESCRIPTION
Filter out hash and refutation moves which have already been searched from the generated legal moves in the move picker 

```
ELO   | 4.62 +- 3.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 17584 W: 4591 L: 4357 D: 8636
```

http://chess.grantnet.us/test/19069/