### PR TITLE
Adjust null-move pruning reduction according to eval 

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -152,7 +152,7 @@ namespace
 
     int nmp_depth(int depth, int eval, int beta)
     {
-        int reduction = std::max(4, 3 + depth / 3) + std::max(0, (eval - beta) / 256);
+        int reduction = std::max(4, 3 + depth / 3) + std::min(2, std::max(0, (eval - beta) / 256));
         return depth - reduction;
     }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -150,9 +150,10 @@ namespace
                score  < -MinMateScore ? score + ply : score;
     }
 
-    int nmp_depth(int depth)
+    int nmp_depth(int depth, int eval, int beta)
     {
-        return depth - std::max(4, 3 + depth / 3);
+        int reduction = std::max(4, 3 + depth / 3) + std::max(0, (eval - beta) / 256);
+        return depth - reduction;
     }
 
     void update_tt_after_search(Search::Info& search, SearchResult result, int depth, int original, int beta, int eval)
@@ -279,7 +280,7 @@ namespace
         if (!pv_node && !in_check && depth >= 4 && do_null && (popcount64(position.get_bb()) >= 4) && eval + 300 >= beta)
         {
             apply_nullmove(search);
-            int score = -pvs(search, nmp_depth(depth), -beta, -beta + 1, false).score;
+            int score = -pvs(search, nmp_depth(depth, eval, beta), -beta, -beta + 1, false).score;
             revert_nullmove(search);
 
             if (search.limits.stopped)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -152,7 +152,7 @@ namespace
 
     int nmp_depth(int depth, int eval, int beta)
     {
-        int reduction = std::max(4, 3 + depth / 3) + std::min(2, std::max(0, (eval - beta) / 256));
+        int reduction = std::max(4, 3 + depth / 3) + std::clamp((eval - beta) / 256, 0, 2);
         return depth - reduction;
     }
 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -27,7 +27,7 @@
 #include "polyglot.h"
 #include <cstring>
 
-const char *version = "8.35";
+const char *version = "8.36";
 
 namespace
 {


### PR DESCRIPTION
Increase null-move pruning reduction as distance between static evaluation and beta increases 

http://chess.grantnet.us/test/19078/

```
ELO   | 3.65 +- 2.94 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 27816 W: 7358 L: 7066 D: 13392
```