### PR TITLE
Improve TT replacement scheme

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -39,7 +39,7 @@ void TTable::add(Position const &position, Move move, int16_t score, uint8_t dep
     uint64_t hash = position.get_key();
     uint64_t index = hash % entries.size(); 
 
-    if (flag != TEFlag::exact && hash == entries[index].hash && depth < entries[index].depth) return;
+    if (flag != TEFlag::exact && hash == entries[index].hash && depth <= entries[index].depth) return;
 
     if (flag == TEFlag::exact || depth * 3 > entries[index].depth)
         entries[index] = TEntry(hash, score, move, depth, flag, seval);

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -39,7 +39,7 @@ void TTable::add(Position const &position, Move move, int16_t score, uint8_t dep
     uint64_t hash = position.get_key();
     uint64_t index = hash % entries.size(); 
 
-    if (flag != TEFlag::exact && hash == entries[index].hash && depth <= entries[index].depth) return;
+    if (flag != TEFlag::exact && hash == entries[index].hash && depth < entries[index].depth - 1) return;
 
     if (flag == TEFlag::exact || depth * 3 > entries[index].depth)
         entries[index] = TEntry(hash, score, move, depth, flag, seval);


### PR DESCRIPTION
Allow replacement of entries with the same hash as long as `new_depth >= old_depth - 1`

http://chess.grantnet.us/test/19100/

```
ELO   | 8.88 +- 5.80 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=2MB
LLR   | 3.09 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 7200 W: 1974 L: 1790 D: 3436
```