### PR TITLE
Fix pthread link issues causing segfault with static builds 

### DIFF
--- a/src/makefile
+++ b/src/makefile
@@ -4,7 +4,7 @@ CXX := g++
 
 EVALFILE = defaultnet.nn
 
-LFLAGS   := -lpthread
+LFLAGS   := -Wl,--whole-archive -lpthread -Wl,--no-whole-archive
 WFLAGS   := -Wall -Wextra
 CXXFLAGS := -std=c++17 $(WFLAGS) -O3 -DNDEBUG -flto -march=native
 RFLAGS   := -std=c++17 -O3 -DNDEBUG -static 

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <cstring>
 #include <algorithm>
 
-const std::string VERSION = "9.09";
+const std::string VERSION = "9.1";
 
 SearchThreadManager THREADS;
 


### PR DESCRIPTION
`make release` which uses the `-static` flag produces builds which segfault on any `stop` or `quit` command. 

Occurs due to issues with linking pthread, no error in code. 
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=58909
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52590

Updated `makefile` and used a workaround for proper linking

