### PR TITLE
Change depth margin for replacing duplicate tt entries 

### DIFF
--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -35,7 +35,7 @@ void TTable::add(Position const &position, Move move, int16_t score, uint8_t dep
     auto hash  = position.get_key();
     auto index = hash % entries.size();
 
-    if (flag != TTFLAG_EXACT && hash == entries[index].hash && depth < entries[index].depth - 1)
+    if (flag != TTFLAG_EXACT && hash == entries[index].hash && depth < entries[index].depth - 2)
         return;
 
     if (flag == TTFLAG_EXACT || depth * 3 > entries[index].depth)

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <cstring>
 #include <algorithm>
 
-const std::string VERSION = "9.1";
+const std::string VERSION = "9.11";
 
 SearchThreadManager THREADS;
 


### PR DESCRIPTION
Change depth margin for replacing duplicate tt entries to `2`

### STC 
http://chess.grantnet.us/test/21259/
```
ELO   | 5.22 +- 3.99 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=2MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 13456 W: 3210 L: 3008 D: 7238
```


### LTC 
http://chess.grantnet.us/test/21262/
```
ELO   | 3.48 +- 2.76 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 22072 W: 4120 L: 3899 D: 14053
```
