### PR TITLE
Tighten conditions for performing null move 

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -242,7 +242,8 @@ SearchResult pvs(SearchInfo &search, int depth, int alpha, int beta, bool do_nul
     if (!pv_node && !in_check && depth == 1 && eval + 400 <= alpha)
         return qsearch(search, alpha, beta);
 
-    if (!pv_node && !in_check && depth >= 4 && do_null && (popcount64(position.get_bb()) >= 4) && eval + 300 >= beta) {
+    const bool is_pawn_eg = !(position.get_bb() & ~(position.get_bb(PT_KING) | position.get_bb(PT_PAWN)));
+    if (!pv_node && !in_check && depth >= 4 && do_null && (popcount64(position.get_bb()) > 5 && !is_pawn_eg) && eval + 300 >= beta) {
         apply_nullmove(search);
         int score = -pvs(search, nmp_depth(depth, eval, beta), -beta, -beta + 1, false).score;
         revert_nullmove(search);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <cstring>
 #include <algorithm>
 
-const std::string VERSION = "9.11";
+const std::string VERSION = "9.12";
 
 SearchThreadManager THREADS;
 


### PR DESCRIPTION
Don't perform null move when it is a pawn endgame, and increase the minimum number of pieces required to be present on the board. 

### LTC 
http://chess.grantnet.us/test/21494/
```
ELO   | 4.10 +- 3.17 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 16432 W: 3033 L: 2839 D: 10560
```

### STC 
http://chess.grantnet.us/test/21486/
```
ELO   | 4.76 +- 3.67 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 15624 W: 3653 L: 3439 D: 8532
```