### PR TITLE
Keep history between searches 

### DIFF
--- a/src/search.h
+++ b/src/search.h
@@ -50,8 +50,6 @@ struct SearchInfo {
     }
 
     void copy_history_tables(SearchInfo const &other) {
-        memcpy(killers, other.killers, sizeof(killers));
-        memcpy(eval, other.eval, sizeof(eval));
         memcpy(history, other.history, sizeof(history));
         memcpy(capture_history, other.capture_history, sizeof(capture_history));
         memcpy(counter_history, other.counter_history, sizeof(counter_history));

--- a/src/search.h
+++ b/src/search.h
@@ -48,6 +48,14 @@ struct SearchInfo {
         memset(counter_history, 0, sizeof(counter_history));
         nodes = seldepth = ply = 0;
     }
+
+    void copy_history_tables(SearchInfo const &other) {
+        memcpy(killers, other.killers, sizeof(killers));
+        memcpy(eval, other.eval, sizeof(eval));
+        memcpy(history, other.history, sizeof(history));
+        memcpy(capture_history, other.capture_history, sizeof(capture_history));
+        memcpy(counter_history, other.counter_history, sizeof(counter_history));
+    }
 };
 
 void init_search_tables();

--- a/src/search_threads.h
+++ b/src/search_threads.h
@@ -28,6 +28,10 @@ public:
         set_threads(1);
     }
 
+    SearchInfo const& get_info() const {
+        return search_data[0];
+    }
+
     void set_threads(size_t count) {
         stop();
         threads.resize(count);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -75,6 +75,7 @@ void uci_go(UciParser const &parser, Position const &position) {
     UciGo options = parser.parse_go();
 
     SearchInfo search;
+    search.copy_history_tables(THREADS.get_info());
     search.position = position;
     search.limits.stopwatch.go();
     search.limits.max_depth = std::min(options.depth, 64);

--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -28,7 +28,7 @@
 #include <cstring>
 #include <algorithm>
 
-const std::string VERSION = "9.13";
+const std::string VERSION = "9.14";
 
 SearchThreadManager THREADS;
 


### PR DESCRIPTION
Copy history tables from previous search when starting a new search 

### LTC 
http://chess.grantnet.us/test/22186/
```
ELO   | 3.51 +- 2.76 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 19904 W: 3356 L: 3155 D: 13393
```


### STC 
http://chess.grantnet.us/test/22185/
```
ELO   | 6.60 +- 4.66 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 9312 W: 2125 L: 1948 D: 5239
```
