### PR TITLE
Reduce less for both killer moves in Late Move Reductions

### DIFF
--- a/src/moveorder.cpp
+++ b/src/moveorder.cpp
@@ -156,6 +156,7 @@ bool MovePicker::next(Move &move) {
 
         if (entry.hash == position.get_key() && can_move(hmove)) {
             move      = hmove;
+            tt_move   = hmove;
             hash_move = move;
             return true;
         }

--- a/src/moveorder.h
+++ b/src/moveorder.h
@@ -43,7 +43,6 @@ public:
     Move hash_move      = MOVE_NULL;
     Move killer1        = MOVE_NULL;
     Move killer2        = MOVE_NULL;
-    Move tt_move        = MOVE_NULL;
 private:
     SearchInfo *search;
     Movelist::iterator current;

--- a/src/moveorder.h
+++ b/src/moveorder.h
@@ -43,7 +43,7 @@ public:
     Move hash_move      = MOVE_NULL;
     Move killer1        = MOVE_NULL;
     Move killer2        = MOVE_NULL;
-
+    Move tt_move        = MOVE_NULL;
 private:
     SearchInfo *search;
     Movelist::iterator current;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -115,17 +115,6 @@ void update_search_result(SearchResult &result, int score, Move move) {
     }
 }
 
-int calculate_lmr_depth(SearchInfo &search, MovePicker &picker, Move move, int depth, int move_i, bool pv_node) {
-    auto R         = LMR_TABLE[depth][std::min(63, move_i)];
-    auto new_depth = depth - 1;
-    R -= pv_node;
-    R -= picker.stage == STAGE_KILLER_2;
-    if (picker.stage == STAGE_QUIET)
-        R -= (get_history(search.history, search.position, move) / 14000);
-    R -= (picker.stage == STAGE_GOOD_NOISY);
-    return std::clamp(new_depth - R, 1, new_depth - 1);
-}
-
 int calculate_rfp_margin(int eval, int depth, bool improving) {
     auto margin = 100 * depth;
     margin /= (improving + 1);
@@ -204,10 +193,12 @@ SearchResult pvs(SearchInfo &search, int depth, int alpha, int beta, bool do_nul
         depth--;
 
     for (Move move; picker.next(move);) {
+        bool is_quiet = !move_is_capture(position, move);
+
         if (move_num > LMP_TABLE[depth][improving])
             break;
 
-        if (depth < 5 && move_is_capture(position, move) && move.score < SP_TABLE[depth])
+        if (depth < 5 && !is_quiet && move.score < SP_TABLE[depth])
             continue;
 
         move_num++;
@@ -215,8 +206,17 @@ SearchResult pvs(SearchInfo &search, int depth, int alpha, int beta, bool do_nul
 
         auto score = 0;
         if (use_lmr(depth, move_num)) {
-            int new_depth = calculate_lmr_depth(search, picker, move, depth, move_num, pv_node);
+            int R         = LMR_TABLE[depth][std::min(63, move_num)];
+            
+            R -= pv_node;
+            R -= move == picker.killer1 || move == picker.killer2;
 
+            if (picker.stage == STAGE_QUIET)
+                R -= get_history(search.history, search.position, move) / 14000;
+
+            R -= picker.stage == STAGE_GOOD_NOISY;
+
+            int new_depth = std::clamp(depth - 1 - R, 1, depth - 2);
             score = -pvs(search, new_depth, -alpha - 1, -alpha).score;
 
             if (score > alpha && new_depth < depth - 1)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -104,10 +104,6 @@ void update_history_tables_on_cutoff(SearchInfo &search, Movelist const &other, 
     }
 }
 
-bool use_lmr(int depth, int move_i) {
-    return depth > 2 && move_i > 3;
-}
-
 void update_search_result(SearchResult &result, int score, Move move) {
     if (score > result.score) {
         result.best_move = move;
@@ -205,7 +201,7 @@ SearchResult pvs(SearchInfo &search, int depth, int alpha, int beta, bool do_nul
         apply_move(search, move);
 
         auto score = 0;
-        if (use_lmr(depth, move_num)) {
+        if (depth > 2 && move_num > 3) {
             int R         = LMR_TABLE[depth][std::min(63, move_num)];
             
             R -= pv_node;

--- a/src/uci.h
+++ b/src/uci.h
@@ -18,6 +18,6 @@
 #pragma once
 #include <string>
 
-const std::string BG_VERSION = "9.15";
+const std::string BG_VERSION = "9.16";
 
 void init_uci(int argc, char **argv);


### PR DESCRIPTION
http://chess.grantnet.us/test/23021/

```
ELO   | 4.42 +- 3.44 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 16816 W: 3733 L: 3519 D: 9564
```