### PR TITLE
Fix halfmoves bug causing invalid draw reports

### DIFF
--- a/src/move.cpp
+++ b/src/move.cpp
@@ -74,7 +74,7 @@ void Position::revert_move() {
 void Position::apply_move(Move move) {
     history[history_ply].move         = move;
     history[history_ply].castle_rooks = castle_rooks;
-    history[history_ply].halfmoves    = halfmoves++;
+    history[history_ply].halfmoves    = halfmoves;
     history[history_ply].hash         = hash;
     history[history_ply].ep_sq        = ep_sq;
     auto &hist_captured = history[history_ply++].captured = PCE_NULL;

--- a/src/uci.h
+++ b/src/uci.h
@@ -18,6 +18,6 @@
 #pragma once
 #include <string>
 
-const std::string BG_VERSION = "9.2";
+const std::string BG_VERSION = "9.21";
 
 void init_uci(int argc, char **argv);


### PR DESCRIPTION
Causing engine to occasionally play losing moves while reporting draw, due to fifty-move rule mistakenly being activated  

http://chess.grantnet.us/test/23705/

```
ELO   | 7.71 +- 6.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
GAMES | N: 5000 W: 1347 L: 1236 D: 2417
```