### PR TITLE
Verify move before updating counter history 

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -88,8 +88,10 @@ void update_history_tables_on_cutoff(SearchInfo &search, Movelist const &other, 
     else {
         update_history(search.history, p, move, other, depth);
 
-        if (p.previous_move() != MOVE_NULL)
-            update_history(search.counter_history, p, move, other, depth);
+        if (p.previous_move() != MOVE_NULL) {
+            if (p.get_piece(move.from()) != PCE_NULL)
+                update_history(search.counter_history, p, move, other, depth);
+        }
         add_killer(search.killers, search.ply, move);
     }
 }


### PR DESCRIPTION
Verify that a move won't cause out-of-bound access when giving bonus to tt move in counter history tables. The TT move can be corrupt and might cause a crash 

50k smp games, no crash

http://chess.grantnet.us/test/23708/

