### PR TITLE
Fix cyclic tc bug 

### DIFF
--- a/src/uci.cpp
+++ b/src/uci.cpp
@@ -87,7 +87,10 @@ void uci_go(UciParser const &parser, Position const &position) {
 
         else {
             search.limits.time_set = true;
-            search.limits.movetime = t / options.movestogo + inc - 50;
+            search.limits.movetime = t / options.movestogo - 50;
+
+            if (options.movestogo != 1) 
+                search.limits.movetime += inc;
         }
     } else {
         search.limits.movetime = options.movetime - 50;

--- a/src/uci.h
+++ b/src/uci.h
@@ -18,6 +18,6 @@
 #pragma once
 #include <string>
 
-const std::string BG_VERSION = "9.23";
+const std::string BG_VERSION = "9.24";
 
 void init_uci(int argc, char **argv);


### PR DESCRIPTION
#212 

Don't add increment to movetime for the last move 