### PR TITLE
Fix missing include

### DIFF
--- a/src/network.h
+++ b/src/network.h
@@ -16,6 +16,7 @@
   along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 #pragma once
+#include <cstdint>
 #include <vector>
 
 #include "net_input.h"


### PR DESCRIPTION
network.h uses fixed-width integer types without including \<cstdint\>, causing a compilation error on Ubuntu 23.10 (GCC 13.2). Fix this.

Bench: 1877660

***

The error in question is:

```
g++ -DEVALFILE=\"defaultnet.nn\" -std=c++17 -Wall -Wextra -O3 -DNDEBUG -flto -march=native *.cpp -Wl,--whole-archive -lpthread -Wl,--no-whole-archive -o Bit-Genie 
In file included from position.h:19,
                 from history.h:21,
                 from search.h:21,
                 from benchmark.cpp:19:
network.h:54:17: error: 'uint32_t' in namespace 'std' does not name a type; did you mean 'wint_t'?
   54 |     static std::uint32_t get_hash() {
      |                 ^~~~~~~~
      |                 wint_t

```
repeated couple of times.

Note: Including \<stdint.h\> didn't work for me, since that doesn't add the typedefs in namespace std.

In general, it would likely be better to include \<cstdint\> (and similar) instead of the respective C headers.
